### PR TITLE
Contiguous Array Storage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Test Python bindings
         run: |
           sudo apt-get install -y wamerican
-          cp target/release/libinstant_distance.so instant-distance-py/test/instant_distance.so
+          cp target/release/libinstant_distance_py.so instant-distance-py/test/instant_distance.so
           PYTHONPATH=instant-distance-py/test/ python3 -m test
 
   lint:

--- a/instant-distance-py/Cargo.toml
+++ b/instant-distance-py/Cargo.toml
@@ -14,6 +14,9 @@ readme = "../README.md"
 name = "instant_distance_py"
 crate-type = ["cdylib", "lib"]
 
+[package.metadata.maturin]
+crate-type = ["cdylib", "lib"]
+
 [dependencies]
 bincode = "1.3.1"
 instant-distance = { version = "0.6", path = "../instant-distance", features = ["with-serde"] }

--- a/instant-distance-py/Cargo.toml
+++ b/instant-distance-py/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/InstantDomain/instant-distance"
 readme = "../README.md"
 
 [lib]
-name = "instant_distance"
-crate-type = ["cdylib"]
+name = "instant_distance_py"
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 bincode = "1.3.1"
@@ -20,3 +20,8 @@ instant-distance = { version = "0.6", path = "../instant-distance", features = [
 pyo3 = { version = "0.20", features = ["extension-module"] }
 serde = { version = "1", features = ["derive"] }
 serde-big-array = "0.5.0"
+
+[dev-dependencies]
+anyhow = "1.0.75"
+clap = { version = "4.4.6", features = ["derive"] }
+tracy_full = { version = "1.5", features = ["enable"] }

--- a/instant-distance-py/examples/perf-fasttext.rs
+++ b/instant-distance-py/examples/perf-fasttext.rs
@@ -1,0 +1,107 @@
+//! This is a simple example of how to use the instant-distance crate to build an index from a file.
+//! The file is expected to be in the format of the fasttext word vectors.
+//!
+//! This example was built to performance using such tools as valgrind, perf, and heaptrack.
+//!
+//! Get the required file:
+//! wget https://dl.fbaipublicfiles.com/fasttext/vectors-aligned/wiki.en.align.vec
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use instant_distance::{Builder, Search};
+use instant_distance_py::FloatArray;
+
+fn main() -> Result<(), anyhow::Error> {
+    let opt = Options::parse();
+    let (words, points) = {
+        let path: &Path = &opt.path;
+        let count = opt.count;
+        let mut words = vec![];
+        let mut points = vec![];
+        let mut reader = BufReader::new(File::open(path)?);
+
+        // skip first line
+        let mut discarded_line = String::new();
+        let _bytes_read = reader.read_line(&mut discarded_line)?;
+
+        for _ in 0..count {
+            let mut line = String::new();
+            let _read_bytes = reader.read_line(&mut line)?;
+            let mut parts = line.split(' ');
+            let word = parts.next().unwrap();
+            words.push(word.to_string());
+            let rest = parts
+                .flat_map(|s| s.trim().parse::<f32>().ok())
+                .collect::<Vec<_>>();
+
+            let mut float_array_inner = [0f32; 300];
+            float_array_inner.copy_from_slice(&rest[..300]);
+            let float_array = FloatArray(float_array_inner);
+
+            points.push(float_array);
+        }
+
+        (words, points)
+    };
+    println!(
+        "{} points loaded, building hnsw(seed: {})...",
+        points.len(),
+        opt.seed
+    );
+
+    let wait = opt.wait;
+    let num_queries = opt.num_queries;
+    let points = points.clone();
+    let start = Instant::now();
+    let hnswmap = Builder::default().seed(opt.seed).build(points, words);
+    println!("contiguous indexing took {:?}", start.elapsed());
+
+    if wait {
+        println!("sleeping for 15s");
+        sleep(Duration::from_millis(15000));
+    }
+
+    let mut search = Search::default();
+    let point = FloatArray([0.0; 300]);
+    for _ in 0..20 {
+        let query_start = Instant::now();
+        for _ in 0..num_queries {
+            let _closest_point = hnswmap.search(&point, &mut search).next().unwrap();
+            tracy_full::frame!("contiguous search");
+        }
+
+        tracy_full::frame!("search group");
+        println!("{} queries took {:?}", num_queries, query_start.elapsed());
+    }
+    tracy_full::frame!();
+
+    Ok(())
+}
+
+#[derive(Parser)]
+struct Options {
+    #[arg(
+        short,
+        default_value = "../instant-distance-benchmarking/wiki.en.align.vec"
+    )]
+    path: PathBuf,
+    #[arg(short, default_value = "50000")]
+    count: usize,
+
+    #[arg(short, default_value = "1000")]
+    num_queries: usize,
+
+    #[arg(short)]
+    wait: bool,
+
+    #[structopt(short, default_value = "123456789")]
+    seed: u64,
+}
+
+#[global_allocator]
+static ALLOC: tracy_full::alloc::GlobalAllocator = tracy_full::alloc::GlobalAllocator::new();

--- a/instant-distance-py/examples/perf-fasttext.rs
+++ b/instant-distance-py/examples/perf-fasttext.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use instant_distance::{Builder, Search};
+
 use instant_distance_py::FloatArray;
 
 fn main() -> Result<(), anyhow::Error> {

--- a/instant-distance-py/pyproject.toml
+++ b/instant-distance-py/pyproject.toml
@@ -4,3 +4,6 @@ name = "instant-distance"
 [build-system]
 requires = ["maturin >= 0.14, < 0.15"]
 build-backend = "maturin"
+
+[tool.maturin]
+python-source = "python"

--- a/instant-distance-py/src/lib.rs
+++ b/instant-distance-py/src/lib.rs
@@ -353,7 +353,7 @@ impl Neighbor {
 
 #[repr(align(32))]
 #[derive(Clone, Deserialize, Serialize)]
-struct FloatArray(#[serde(with = "BigArray")] [f32; DIMENSIONS]);
+pub struct FloatArray(#[serde(with = "BigArray")] pub [f32; DIMENSIONS]);
 
 impl TryFrom<&PyAny> for FloatArray {
     type Error = PyErr;
@@ -373,6 +373,7 @@ impl TryFrom<&PyAny> for FloatArray {
 impl Point for FloatArray {
     const STRIDE: usize = DIMENSIONS;
     type Element = f32;
+
     fn as_slice(&self) -> &[Self::Element] {
         &self.0
     }

--- a/instant-distance/examples/colors.rs
+++ b/instant-distance/examples/colors.rs
@@ -1,26 +1,35 @@
 use instant_distance::{Builder, Search};
 
 fn main() {
-    let points = vec![Point(255, 0, 0), Point(0, 255, 0), Point(0, 0, 255)];
+    let points = vec![Point([255, 0, 0]), Point([0, 255, 0]), Point([0, 0, 255])];
     let values = vec!["red", "green", "blue"];
 
     let map = Builder::default().build(points, values);
     let mut search = Search::default();
 
-    let burnt_orange = Point(204, 85, 0);
-
-    let closest_point = map.search(&burnt_orange, &mut search).next().unwrap();
+    let closest_point = map
+        .search(&Point([204, 85, 0]), &mut search)
+        .next()
+        .unwrap();
 
     println!("{:?}", closest_point.value);
 }
 
 #[derive(Clone, Copy, Debug)]
-struct Point(isize, isize, isize);
+struct Point([isize; 3]);
 
 impl instant_distance::Point for Point {
+    const STRIDE: usize = 3;
+    type Element = isize;
+    fn as_slice(&self) -> &[Self::Element] {
+        &self.0
+    }
+
     fn distance(&self, other: &Self) -> f32 {
         // Euclidean distance metric
-        (((self.0 - other.0).pow(2) + (self.1 - other.1).pow(2) + (self.2 - other.2).pow(2)) as f32)
+        (((self.0[0] - other.0[0]).pow(2)
+            + (self.0[1] - other.0[1]).pow(2)
+            + (self.0[2] - other.0[2]).pow(2)) as f32)
             .sqrt()
     }
 }

--- a/instant-distance/src/contiguous.rs
+++ b/instant-distance/src/contiguous.rs
@@ -1,0 +1,37 @@
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+use crate::types::{LayerId, Meta, INVALID};
+use crate::{Builder, Point, PointId};
+
+/// Give all points a random layer and sort the list of nodes by descending order for
+/// construction. This allows us to copy higher layers to lower layers as construction
+/// progresses, while preserving randomness in each point's layer and insertion order.
+pub(crate) fn shuffle_points_for_layer_assignment<P: Point>(
+    points: Vec<P>,
+    meta: &Meta,
+    builder: Builder,
+) -> (Vec<P>, Vec<PointId>, Vec<(LayerId, PointId)>) {
+    let mut rng = SmallRng::seed_from_u64(builder.seed);
+    assert!(points.len() < u32::MAX as usize);
+    let mut shuffled = (0..points.len())
+        .map(|i| (PointId(rng.gen_range(0..points.len() as u32)), i))
+        .collect::<Vec<_>>();
+    shuffled.sort_unstable();
+
+    let mut out = vec![INVALID; points.len()];
+    let mut new_points = Vec::with_capacity(points.len());
+    let mut new_nodes = Vec::with_capacity(points.len());
+    let mut at_layer = meta.next_lower(None).unwrap();
+    for (i, (_, idx)) in shuffled.into_iter().enumerate() {
+        let pid = PointId(new_nodes.len() as u32);
+        if i == at_layer.1 {
+            at_layer = meta.next_lower(Some(at_layer.0)).unwrap();
+        }
+        new_points.push(points[idx].clone());
+        new_nodes.push((at_layer.0, pid));
+        out[idx] = pid;
+    }
+    debug_assert_eq!(new_nodes.first().unwrap().0, LayerId(meta.len() - 1));
+    debug_assert_eq!(new_nodes.last().unwrap().0, LayerId(0));
+    (new_points, out, new_nodes)
+}

--- a/instant-distance/src/contiguous.rs
+++ b/instant-distance/src/contiguous.rs
@@ -10,7 +10,6 @@ use crate::{Builder, Element, Point, PointId};
 pub struct PointIter<'a, E, P: Point<Element = E>> {
     values: &'a [P::Element],
     index: usize,
-    _marker: PhantomData<&'a P>,
 }
 
 impl<'a, E, P: Point<Element = E>> Iterator for PointIter<'a, E, P> {
@@ -31,7 +30,6 @@ pub trait Storage<E, P: Point<Element = E>> {
     fn is_empty(&self) -> bool;
 }
 
-// TODO: remove default N
 pub struct PointRef<'a, E, P: Point<Element = E>>(pub &'a [P::Element]);
 
 impl<'a, E, P: Point<Element = E>> PointRef<'a, E, P> {
@@ -109,7 +107,6 @@ impl<'a, E: Element + 'a, P: Point<Element = E>> Storage<E, P> for ContiguousSto
         PointIter {
             values: &self.values,
             index: 0,
-            _marker: PhantomData,
         }
     }
 

--- a/instant-distance/src/contiguous.rs
+++ b/instant-distance/src/contiguous.rs
@@ -1,37 +1,143 @@
+use std::marker::PhantomData;
+
 use rand::{rngs::SmallRng, Rng, SeedableRng};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::types::{LayerId, Meta, INVALID};
-use crate::{Builder, Point, PointId};
+use crate::{Builder, Element, Point, PointId};
 
-/// Give all points a random layer and sort the list of nodes by descending order for
-/// construction. This allows us to copy higher layers to lower layers as construction
-/// progresses, while preserving randomness in each point's layer and insertion order.
-pub(crate) fn shuffle_points_for_layer_assignment<P: Point>(
-    points: Vec<P>,
-    meta: &Meta,
-    builder: Builder,
-) -> (Vec<P>, Vec<PointId>, Vec<(LayerId, PointId)>) {
-    let mut rng = SmallRng::seed_from_u64(builder.seed);
-    assert!(points.len() < u32::MAX as usize);
-    let mut shuffled = (0..points.len())
-        .map(|i| (PointId(rng.gen_range(0..points.len() as u32)), i))
-        .collect::<Vec<_>>();
-    shuffled.sort_unstable();
+pub struct PointIter<'a, E, P: Point<Element = E>> {
+    values: &'a [P::Element],
+    index: usize,
+    _marker: PhantomData<&'a P>,
+}
 
-    let mut out = vec![INVALID; points.len()];
-    let mut new_points = Vec::with_capacity(points.len());
-    let mut new_nodes = Vec::with_capacity(points.len());
-    let mut at_layer = meta.next_lower(None).unwrap();
-    for (i, (_, idx)) in shuffled.into_iter().enumerate() {
-        let pid = PointId(new_nodes.len() as u32);
-        if i == at_layer.1 {
-            at_layer = meta.next_lower(Some(at_layer.0)).unwrap();
-        }
-        new_points.push(points[idx].clone());
-        new_nodes.push((at_layer.0, pid));
-        out[idx] = pid;
+impl<'a, E, P: Point<Element = E>> Iterator for PointIter<'a, E, P> {
+    type Item = PointRef<'a, E, P>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let start = self.index * P::STRIDE;
+        let end = start + P::STRIDE;
+        self.index += 1;
+        self.values.get(start..end).map(PointRef)
     }
-    debug_assert_eq!(new_nodes.first().unwrap().0, LayerId(meta.len() - 1));
-    debug_assert_eq!(new_nodes.last().unwrap().0, LayerId(0));
-    (new_points, out, new_nodes)
+}
+
+pub trait Storage<E, P: Point<Element = E>> {
+    fn iter(&self) -> PointIter<'_, E, P>;
+    fn get(&self, index: usize) -> Option<PointRef<'_, E, P>>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
+}
+
+// TODO: remove default N
+pub struct PointRef<'a, E, P: Point<Element = E>>(pub &'a [P::Element]);
+
+impl<'a, E, P: Point<Element = E>> PointRef<'a, E, P> {
+    pub fn from_data(values: &'a [P::Element]) -> Self {
+        Self(values)
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Default)]
+pub struct ContiguousStorage<E: Element, P: Point<Element = E>> {
+    pub values: Vec<E>,
+    _phantom: PhantomData<P>,
+}
+
+impl<E: Element, P: Point<Element = E>> ContiguousStorage<E, P> {
+    pub(crate) fn empty() -> Self {
+        Self {
+            values: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+    pub(crate) fn new(
+        points: Vec<P>,
+        meta: &Meta,
+        builder: Builder,
+    ) -> (Self, Vec<PointId>, Vec<(LayerId, PointId)>) {
+        let mut rng = SmallRng::seed_from_u64(builder.seed);
+        let points_len = points.len();
+        assert!(points.len() < u32::MAX as usize);
+        let mut shuffled = (0..points_len)
+            .map(|i| (PointId(rng.gen_range(0..points_len as u32)), i))
+            .zip(points)
+            .collect::<Vec<_>>();
+        shuffled.sort_unstable_by_key(|(pid, _)| *pid);
+
+        let mut new_points = Vec::with_capacity(points_len);
+        let mut layer_assignments = Vec::with_capacity(points_len);
+        let mut out = vec![INVALID; points_len];
+        let mut at_layer = meta.next_lower(None).unwrap();
+        for (i, ((_, idx), point)) in shuffled.into_iter().enumerate() {
+            let pid = PointId(layer_assignments.len() as u32);
+            if i == at_layer.1 {
+                at_layer = meta.next_lower(Some(at_layer.0)).unwrap();
+            }
+
+            new_points.push(point);
+            layer_assignments.push((at_layer.0, pid));
+            out[idx] = pid;
+        }
+
+        debug_assert_eq!(
+            layer_assignments.first().unwrap().0,
+            LayerId(meta.len() - 1)
+        );
+        debug_assert_eq!(layer_assignments.last().unwrap().0, LayerId(0));
+
+        (
+            Self {
+                values: new_points
+                    .iter()
+                    .flat_map(Point::as_slice)
+                    .copied()
+                    .collect::<Vec<_>>(),
+                _phantom: PhantomData,
+            },
+            out,
+            layer_assignments,
+        )
+    }
+}
+
+impl<'a, E: Element + 'a, P: Point<Element = E>> Storage<E, P> for ContiguousStorage<E, P> {
+    fn iter(&self) -> PointIter<'_, E, P> {
+        PointIter {
+            values: &self.values,
+            index: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    fn get(&self, index: usize) -> Option<PointRef<'_, E, P>> {
+        self.values
+            .get(index * P::STRIDE..(index + 1) * P::STRIDE)
+            .map(PointRef)
+    }
+
+    fn len(&self) -> usize {
+        self.values.len().saturating_div(P::STRIDE)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+// blanket impl
+impl<E: Element, P: Point<Element = E>> Point for PointRef<'_, E, P> {
+    const STRIDE: usize = P::STRIDE;
+    type Element = E;
+
+    fn as_slice(&self) -> &[Self::Element] {
+        self.0
+    }
+
+    fn distance(&self, other: &Self) -> f32 {
+        Element::distance(self.0, other.0)
+    }
 }

--- a/instant-distance/src/lib.rs
+++ b/instant-distance/src/lib.rs
@@ -1,7 +1,6 @@
 use std::cmp::{Ordering, Reverse};
 use std::collections::BinaryHeap;
 use std::collections::HashSet;
-use std::marker::PhantomData;
 use std::ops::Range;
 #[cfg(feature = "indicatif")]
 use std::sync::atomic::{self, AtomicUsize};
@@ -16,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 mod contiguous;
 use contiguous::ContiguousStorage;
-mod simd;
+pub mod simd;
 pub use contiguous::{PointRef, Storage};
 mod types;
 use simd::{distance_simd_f32, distance_simd_f64};
@@ -195,7 +194,6 @@ pub struct MapItem<'a, E, P: Point<Element = E>, V> {
     pub pid: PointId,
     pub point: PointRef<'a, E, P>,
     pub value: &'a V,
-    _marker: PhantomData<&'a P>,
 }
 
 impl<'a, E: Element, P: Point<Element = E>, V> MapItem<'a, E, P, V> {
@@ -205,7 +203,6 @@ impl<'a, E: Element, P: Point<Element = E>, V> MapItem<'a, E, P, V> {
             pid: item.pid,
             point: item.point,
             value: &map.values[item.pid.0 as usize],
-            _marker: PhantomData,
         }
     }
 }

--- a/instant-distance/src/lib.rs
+++ b/instant-distance/src/lib.rs
@@ -429,18 +429,21 @@ impl<'a, P: Point> Construction<'a, P> {
             // `candidate` here is the new node's neighbor
             let &Candidate { distance, pid } = candidate;
             if let Some(heuristic) = self.heuristic {
+                let mut candidate_write_lock = self.zero[pid].write();
+                let current = candidate_write_lock
+                    .iter()
+                    .take_while(|p| p.is_valid())
+                    .copied();
                 let found = insertion.add_neighbor_heuristic(
                     new,
-                    self.zero.nearest_iter(pid),
+                    current,
                     self.zero,
                     &self.points[pid],
                     self.points,
                     heuristic,
                 );
 
-                self.zero[pid]
-                    .write()
-                    .rewrite(found.iter().map(|candidate| candidate.pid));
+                candidate_write_lock.rewrite(found.iter().map(|candidate| candidate.pid))
             } else {
                 // Find the correct index to insert at to keep the neighbor's neighbors sorted
                 let old = &self.points[pid];

--- a/instant-distance/src/simd.rs
+++ b/instant-distance/src/simd.rs
@@ -1,0 +1,99 @@
+//! SIMD implementations of distance functions.
+
+pub(crate) fn distance_simd_f64(lhs: &[f64], rhs: &[f64]) -> f64 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        use std::arch::x86_64::{
+            _mm256_add_pd, _mm256_castpd256_pd128, _mm256_extractf128_pd, _mm256_loadu_pd,
+            _mm256_mul_pd, _mm256_setzero_pd, _mm256_sub_pd, _mm_add_pd, _mm_add_sd, _mm_cvtsd_f64,
+            _mm_unpackhi_pd,
+        };
+        debug_assert_eq!(lhs.len(), rhs.len());
+
+        unsafe {
+            let mut acc_4x = _mm256_setzero_pd();
+            for (lh_slice, rh_slice) in lhs.chunks_exact(4).zip(rhs.chunks_exact(4)) {
+                let lh_4x = _mm256_loadu_pd(lh_slice.as_ptr());
+                let rh_4x = _mm256_loadu_pd(rh_slice.as_ptr());
+                let diff = _mm256_sub_pd(lh_4x, rh_4x);
+                let diff_squared = _mm256_mul_pd(diff, diff);
+                acc_4x = _mm256_add_pd(diff_squared, acc_4x);
+            }
+
+            // Sum up the components in `acc_4x`
+            let acc_high = _mm256_extractf128_pd(acc_4x, 1);
+            let acc_low = _mm256_castpd256_pd128(acc_4x);
+            let acc_2x = _mm_add_pd(acc_high, acc_low);
+
+            let mut acc = _mm_add_pd(acc_2x, _mm_unpackhi_pd(acc_2x, acc_2x));
+            acc = _mm_add_sd(acc, _mm_unpackhi_pd(acc, acc));
+
+            let remaining_elements = &lhs[lhs.len() - lhs.len() % 4..];
+            let mut residual = 0.0;
+            for (&lh, &rh) in remaining_elements
+                .iter()
+                .zip(rhs[lhs.len() - lhs.len() % 4..].iter())
+            {
+                residual += (lh - rh).powi(2);
+            }
+
+            let residual = residual + _mm_cvtsd_f64(acc);
+            residual.sqrt()
+        }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    lhs.iter()
+        .zip(rhs.iter())
+        .map(|(a, b)| (*a - *b).pow(2))
+        .sum::<f32>()
+        .sqrt()
+}
+
+pub(crate) fn distance_simd_f32(lhs: &[f32], rhs: &[f32]) -> f32 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        use std::arch::x86_64::{
+            _mm256_add_ps, _mm256_castps256_ps128, _mm256_extractf128_ps, _mm256_loadu_ps,
+            _mm256_mul_ps, _mm256_setzero_ps, _mm256_sub_ps, _mm_add_ps, _mm_add_ss, _mm_cvtss_f32,
+            _mm_movehl_ps, _mm_shuffle_ps,
+        };
+        debug_assert_eq!(lhs.len(), rhs.len());
+
+        unsafe {
+            let mut acc_8x = _mm256_setzero_ps();
+            for (lh_slice, rh_slice) in lhs.chunks_exact(8).zip(rhs.chunks_exact(8)) {
+                let lh_8x = _mm256_loadu_ps(lh_slice.as_ptr());
+                let rh_8x = _mm256_loadu_ps(rh_slice.as_ptr());
+                let diff = _mm256_sub_ps(lh_8x, rh_8x);
+                let diff_squared = _mm256_mul_ps(diff, diff);
+                acc_8x = _mm256_add_ps(diff_squared, acc_8x);
+            }
+
+            // Sum up the components in `acc_8x`
+            let acc_high = _mm256_extractf128_ps(acc_8x, 1);
+            let acc_low = _mm256_castps256_ps128(acc_8x);
+            let acc_4x = _mm_add_ps(acc_high, acc_low);
+
+            let mut acc = _mm_add_ps(acc_4x, _mm_movehl_ps(acc_4x, acc_4x));
+            acc = _mm_add_ss(acc, _mm_shuffle_ps(acc, acc, 0x55));
+
+            let remaining_elements = &lhs[lhs.len() - lhs.len() % 8..];
+            let mut residual = 0.0;
+            for (&lh, &rh) in remaining_elements
+                .iter()
+                .zip(rhs[lhs.len() - lhs.len() % 8..].iter())
+            {
+                residual += (lh - rh).powi(2);
+            }
+
+            let residual = residual + _mm_cvtss_f32(acc);
+            residual.sqrt()
+        }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    lhs.iter()
+        .zip(rhs.iter())
+        .map(|(a, b)| (*a - *b).pow(2) as f32)
+        .sum::<f32>()
+        .sqrt()
+}

--- a/instant-distance/src/types.rs
+++ b/instant-distance/src/types.rs
@@ -9,7 +9,7 @@ use rayon::slice::ParallelSliceMut;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{Hnsw, Point, M};
+use crate::M;
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, Default)]
@@ -219,7 +219,7 @@ impl<'a> LayerSliceMut<'a> {
             .par_chunks_mut(stride)
             .zip(zero)
             .for_each(|(dst, src)| {
-                dst.copy_from_slice(&src.read()[..stride]);
+                dst.copy_from_slice(&src.read().0[..stride]);
             });
     }
 
@@ -326,7 +326,7 @@ impl Iterator for DescendingLayerIter {
 }
 
 /// A potential nearest neighbor
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Candidate {
     pub(crate) distance: OrderedFloat<f32>,
     /// The identifier for the neighboring point
@@ -363,22 +363,6 @@ impl From<u32> for PointId {
 impl Default for PointId {
     fn default() -> Self {
         INVALID
-    }
-}
-
-impl<P> Index<PointId> for Hnsw<P> {
-    type Output = P;
-
-    fn index(&self, index: PointId) -> &Self::Output {
-        &self.points[index.0 as usize]
-    }
-}
-
-impl<P: Point> Index<PointId> for [P] {
-    type Output = P;
-
-    fn index(&self, index: PointId) -> &Self::Output {
-        &self[index.0 as usize]
     }
 }
 

--- a/instant-distance/tests/all.rs
+++ b/instant-distance/tests/all.rs
@@ -7,6 +7,46 @@ use rand::{Rng, SeedableRng};
 use instant_distance::{Builder, Point as _, Search};
 
 #[test]
+fn neighbors_regression() {
+    for _ in 0..10 {
+        let points = (0..5)
+            .map(|i| Point(i as f32, i as f32))
+            .collect::<Vec<_>>();
+        let values = vec!["zero", "one", "two", "three", "four"];
+
+        let seed = 12345689;
+        println!("\nmap (seed = {seed})");
+        let map = Builder::default().seed(seed).build(points, values);
+
+        let values = map
+            .values
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i, v))
+            .collect::<Vec<_>>();
+
+        println!("values reordered {:?}", values);
+
+        let mut search = Search::default();
+
+        let search_results = map
+            .search(&Point(2.0, 2.0), &mut search)
+            .map(|item| (item.distance, item.value))
+            .collect::<Vec<_>>();
+
+        println!("search results {:?}", search_results);
+
+        assert_eq!(*search_results[0].1, "two");
+        assert_eq!(*search_results[1].1, "one");
+        assert_eq!(*search_results[2].1, "three");
+        assert_eq!(*search_results[3].1, "four");
+        assert_eq!(*search_results[4].1, "zero");
+
+        assert_eq!(search_results.len(), 5);
+    }
+}
+
+#[test]
 #[allow(clippy::float_cmp, clippy::approx_constant)]
 fn map() {
     let points = (0..5)


### PR DESCRIPTION
This PR pulls in the `neighbors` branch which makes storage backing the HNSW contiguous, but also goes further to flatten input types to a provide a single backing `Vec<f32>` (with stride information) and therein hope to glean the benefit of contiguous array access.

I've added a `Point` implementation for `&[f32]` and optimistically I'm plumbing that through as the underlying indexing and querying.

I'm marking this as WIP for now because I want to get feedback on this before pushing it further ahead. It also still has some extra dependencies on things like `tracy` that aren't desirable to merge, but are useful for profiling. 

As far as my measurements go, the performance seems to be approximately the same as before the change. It seems that each indexing of an HNSW will produce a structure that differs in performance, and that could be due to randomized locality for graph nodes.