### PR TITLE
Fix `extend_candidates` deadlock

### DIFF
--- a/instant-distance/src/lib.rs
+++ b/instant-distance/src/lib.rs
@@ -435,7 +435,6 @@ impl<'a, P: Point> Construction<'a, P> {
     /// Creates the new node, initializing its `nearest` array and updates the nearest neighbors
     /// for the new node's neighbors if necessary before appending the new node to the layer.
     fn insert(&self, new: PointId, layer: LayerId, layers: &[Vec<UpperNode>]) {
-        let mut node = self.zero[new].write();
         let (mut search, mut insertion) = self.pool.pop();
         insertion.ef = self.ef_construction;
 
@@ -513,7 +512,7 @@ impl<'a, P: Point> Construction<'a, P> {
 
                 self.zero[pid].write().insert(idx, new);
             }
-            node.set(i, pid);
+            self.zero[new].write().set(i, pid);
         }
 
         #[cfg(feature = "indicatif")]

--- a/instant-distance/tests/all.rs
+++ b/instant-distance/tests/all.rs
@@ -4,7 +4,24 @@ use ordered_float::OrderedFloat;
 use rand::rngs::{StdRng, ThreadRng};
 use rand::{Rng, SeedableRng};
 
-use instant_distance::{Builder, Point as _, Search};
+use instant_distance::{Builder, Heuristic, Point as _, Search};
+
+#[test]
+fn extend_candidates() {
+    let seed = ThreadRng::default().gen::<u64>();
+    println!("extend_candidates (seed = {seed})");
+    let mut rng = StdRng::seed_from_u64(seed);
+    let points = (0..1024)
+        .map(|_| Point(rng.gen(), rng.gen()))
+        .collect::<Vec<_>>();
+    Builder::default()
+        .select_heuristic(Some(Heuristic {
+            extend_candidates: true,
+            ..Default::default()
+        }))
+        .seed(seed)
+        .build_hnsw(points);
+}
 
 #[test]
 #[allow(clippy::float_cmp, clippy::approx_constant)]


### PR DESCRIPTION
Addresses #49

A previously-held write lock was deadlocking when in `select_heuristic` a `nearest_iter()` call would attempt a read lock on the same node.

This PR adds a new type, `MultiLockedLayer`, which is aware of what node is already locked, and uses that to reference the already-taken write lock for reads when we update candidates.